### PR TITLE
Normalize and clamp ROI bounds to avoid OOB slices; update README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Video brightness analysis tool for electrochemiluminescence (ECL) experiments. M
 ```bash
 # 1. Clone the repo
 git clone https://github.com/nedcut/ECL_Analysis.git
-cd ecl
+cd ECL_Analysis
 
 # 2. Create a virtual environment
 python3 -m venv .venv
@@ -27,7 +27,7 @@ python main.py
 Whenever updates are pushed, run these commands to get the latest version:
 
 ```bash
-cd ecl
+cd ECL_Analysis
 source .venv/bin/activate
 git pull
 pip install -r requirements.txt   # only needed if dependencies changed

--- a/ecl_analysis/analysis/background.py
+++ b/ecl_analysis/analysis/background.py
@@ -28,10 +28,23 @@ def compute_background_brightness(
 
     try:
         pt1, pt2 = rects[background_roi_idx]
+        frame_height, frame_width = frame.shape[:2]
+
+        left, right = sorted((int(pt1[0]), int(pt2[0])))
+        top, bottom = sorted((int(pt1[1]), int(pt2[1])))
+
+        x1 = max(0, min(left, frame_width))
+        x2 = max(0, min(right, frame_width))
+        y1 = max(0, min(top, frame_height))
+        y2 = max(0, min(bottom, frame_height))
+
+        if x2 <= x1 or y2 <= y1:
+            return None
+
         if frame_l_star is not None:
-            roi_l_star = frame_l_star[pt1[1] : pt2[1], pt1[0] : pt2[0]]
+            roi_l_star = frame_l_star[y1:y2, x1:x2]
         else:
-            roi = frame[pt1[1] : pt2[1], pt1[0] : pt2[0]]
+            roi = frame[y1:y2, x1:x2]
             if roi.size == 0:
                 return None
             roi_l_star = compute_l_star_frame(roi)

--- a/ecl_analysis/workers.py
+++ b/ecl_analysis/workers.py
@@ -16,6 +16,24 @@ from .analysis.models import AnalysisRequest, AnalysisResult, RoiRect
 from .audio import AudioAnalyzer
 
 
+def _normalized_slice_bounds(
+    pt1: tuple[int, int],
+    pt2: tuple[int, int],
+    frame_width: int,
+    frame_height: int,
+) -> tuple[int, int, int, int]:
+    """Return clamped, normalized ROI bounds for NumPy slicing (exclusive end)."""
+    left, right = sorted((int(pt1[0]), int(pt2[0])))
+    top, bottom = sorted((int(pt1[1]), int(pt2[1])))
+
+    x1 = max(0, min(left, frame_width))
+    x2 = max(0, min(right, frame_width))
+    y1 = max(0, min(top, frame_height))
+    y2 = max(0, min(bottom, frame_height))
+
+    return x1, y1, x2, y2
+
+
 @dataclass(frozen=True)
 class MaskScanRequest:
     """Immutable scan inputs for brightest-frame mask workflows."""
@@ -112,8 +130,7 @@ class AnalysisWorker(QtCore.QObject):
                 frame_height, frame_width = frame.shape[:2]
                 for data_idx, roi_idx in enumerate(non_background_rois):
                     pt1, pt2 = req.rects[roi_idx]
-                    x1, y1 = max(0, pt1[0]), max(0, pt1[1])
-                    x2, y2 = min(frame_width - 1, pt2[0]), min(frame_height - 1, pt2[1])
+                    x1, y1, x2, y2 = _normalized_slice_bounds(pt1, pt2, frame_width, frame_height)
 
                     if x2 > x1 and y2 > y1:
                         roi = frame[y1:y2, x1:x2]
@@ -291,8 +308,7 @@ class BrightestFrameWorker(QtCore.QObject):
 
                 for roi_idx in non_background_rois:
                     pt1, pt2 = req.rects[roi_idx]
-                    x1, y1 = max(0, pt1[0]), max(0, pt1[1])
-                    x2, y2 = min(frame_width - 1, pt2[0]), min(frame_height - 1, pt2[1])
+                    x1, y1, x2, y2 = _normalized_slice_bounds(pt1, pt2, frame_width, frame_height)
                     if x2 > x1 and y2 > y1:
                         roi_l_star = l_star_frame[y1:y2, x1:x2]
                         if roi_l_star.size:
@@ -387,8 +403,7 @@ class PerRoiMaskCaptureWorker(QtCore.QObject):
 
                 for roi_idx in roi_indices:
                     pt1, pt2 = req.rects[roi_idx]
-                    x1, y1 = max(0, pt1[0]), max(0, pt1[1])
-                    x2, y2 = min(frame_width - 1, pt2[0]), min(frame_height - 1, pt2[1])
+                    x1, y1, x2, y2 = _normalized_slice_bounds(pt1, pt2, frame_width, frame_height)
                     if x2 > x1 and y2 > y1:
                         roi_l_star = l_star_frame[y1:y2, x1:x2]
                         if roi_l_star.size:
@@ -429,8 +444,7 @@ class PerRoiMaskCaptureWorker(QtCore.QObject):
 
                 frame_height, frame_width = frame.shape[:2]
                 pt1, pt2 = req.rects[roi_idx]
-                x1, y1 = max(0, pt1[0]), max(0, pt1[1])
-                x2, y2 = min(frame_width - 1, pt2[0]), min(frame_height - 1, pt2[1])
+                x1, y1, x2, y2 = _normalized_slice_bounds(pt1, pt2, frame_width, frame_height)
 
                 if x2 > x1 and y2 > y1:
                     roi_l_star = l_star_frame[y1:y2, x1:x2]

--- a/tests/integration/test_workers.py
+++ b/tests/integration/test_workers.py
@@ -108,6 +108,34 @@ def test_brightest_frame_worker_picks_max_frame(monkeypatch):
     assert result.brightest_frame_idx == 1
 
 
+def test_brightest_frame_worker_handles_edge_touching_roi(monkeypatch):
+    frame0 = np.zeros((4, 4, 3), dtype=np.uint8)
+    frame1 = np.zeros((4, 4, 3), dtype=np.uint8)
+    frame1[:, 3:4, :] = 255
+    frames = [frame0, frame1]
+    monkeypatch.setattr(cv2, "VideoCapture", lambda _path: DummyVideoCapture(frames))
+
+    request = MaskScanRequest(
+        video_path="dummy.mp4",
+        rects=[((3, 0), (4, 4))],
+        background_roi_idx=None,
+        start_frame=0,
+        end_frame=1,
+        step=1,
+        background_percentile=90.0,
+        morphological_kernel_size=3,
+    )
+
+    worker = BrightestFrameWorker(request)
+    captured: Dict[str, object] = {}
+    worker.finished.connect(lambda payload: captured.setdefault("result", payload))
+    worker.run()
+
+    result = captured.get("result")
+    assert isinstance(result, BrightestFrameResult)
+    assert result.brightest_frame_idx == 1
+
+
 def test_per_roi_mask_capture_worker_returns_sources(monkeypatch):
     frame0 = np.zeros((4, 4, 3), dtype=np.uint8)
     frame1 = np.zeros((4, 4, 3), dtype=np.uint8)

--- a/tests/unit/test_analysis_background.py
+++ b/tests/unit/test_analysis_background.py
@@ -57,3 +57,35 @@ def test_compute_background_brightness_without_precomputed_l_star():
 
     assert result is not None
     assert result > 0.0
+
+
+def test_compute_background_brightness_normalizes_and_clamps_rect():
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    frame[0:4, 0:2, :] = 200
+    rects = [((2, 4), (-3, -1))]  # reversed and out-of-bounds
+
+    result = compute_background_brightness(
+        frame=frame,
+        rects=rects,
+        background_roi_idx=0,
+        background_percentile=50.0,
+    )
+
+    expected_l_star = compute_l_star_frame(frame[:, 0:2])
+    expected = float(np.percentile(expected_l_star, 50.0))
+    assert result is not None
+    assert result == pytest.approx(expected, rel=1e-6)
+
+
+def test_compute_background_brightness_returns_none_when_clamped_roi_empty():
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    rects = [((10, 10), (12, 12))]
+
+    result = compute_background_brightness(
+        frame=frame,
+        rects=rects,
+        background_roi_idx=0,
+        background_percentile=90.0,
+    )
+
+    assert result is None


### PR DESCRIPTION
### Motivation
- Prevent out-of-bounds or inverted ROI coordinates from causing empty slices or crashes during brightness analysis and mask capture. 
- Ensure edge-touching ROIs (coordinates at frame borders) are handled deterministically. 
- Correct the repository directory name in the Quick Start instructions in `README.md`.

### Description
- Added `_normalized_slice_bounds` helper to `ecl_analysis/workers.py` to clamp and normalize ROI coordinates for NumPy slicing. 
- Replaced ad-hoc bounds calculations in workers with calls to `_normalized_slice_bounds`, and updated slicing sites to use the returned normalized bounds. 
- Hardened `compute_background_brightness` in `ecl_analysis/analysis/background.py` to clamp ROI coordinates, check for empty/clamped ROIs, and return `None` for invalid regions. 
- Updated `README.md` quick start and update instructions to use `cd ECL_Analysis` instead of `cd ecl`.
- Added integration and unit tests to exercise edge-touching and out-of-bounds ROI behavior (`tests/integration/test_workers.py` and `tests/unit/test_analysis_background.py`).

### Testing
- Ran the unit tests covering background computation with `pytest tests/unit/test_analysis_background.py` and confirmed the new cases for clamped ROIs and empty-clamped ROIs passed. 
- Ran the integration tests `tests/integration/test_workers.py` to verify brightest-frame selection for edge-touching ROIs and observed the new test passed. 
- Ran the full test suite with `pytest -q` to validate the changes across workers and analysis modules and observed successful test completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef09a332c832bbde206b1d0f712c2)